### PR TITLE
#3613 fixing off-by-one error on compiler errors

### DIFF
--- a/build.py
+++ b/build.py
@@ -309,7 +309,7 @@ goog.provide('Blockly.utils.string');
     def file_lookup(name):
       if not name.startswith("Input_"):
         return "???"
-      n = int(name[6:]) - 1
+      n = int(name[6:])
       return filenames[n]
 
     if "serverErrors" in json_data:


### PR DESCRIPTION
As both the python filename array and the Input_X indexing is 0 based, the `-1` operation is not needed.

fromFileArray in closure-compiler uses 0 based indexing. see:

https://github.com/google/closure-compiler/blob/09cca3b536923dfb86d4e2ea34c8ee97d3ab471c/src/com/google/javascript/jscomp/gwt/client/JsRunnerMain.java#L816

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/3613